### PR TITLE
Add support for indexing subscription update members command

### DIFF
--- a/services/blockchain-indexer/shared/dataService/business/subscriptions.js
+++ b/services/blockchain-indexer/shared/dataService/business/subscriptions.js
@@ -35,7 +35,7 @@ const getSubscriptions = async (params = {}) => {
 		subscriptionSet,
 		async subscription => {
 			const membersSet = await membersTable.find(
-				{ shared: subscription.subscriptionID },
+				{ shared: subscription.subscriptionID, removedBy: null },
 				['address'],
 			);
 			subscription.members = membersSet.map(member => ({ address: member.address }));

--- a/services/blockchain-indexer/shared/database/schema/members.js
+++ b/services/blockchain-indexer/shared/database/schema/members.js
@@ -1,9 +1,12 @@
 module.exports = {
 	tableName: 'members',
-	primaryKey: 'address',
+	primaryKey: 'id',
 	schema: {
+		id: { type: 'string' },
 		address: { type: 'string' },
 		shared: { type: 'string', null: true },
+		addedBy: { type: 'string', null: true },
+		removedBy: { type: 'string', null: true },
 	},
 	indexes: {
 		shared: { type: 'key' },

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/subscription/purchase.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/subscription/purchase.js
@@ -66,7 +66,9 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 			logger.debug(`Updated account index for the account with address ${member}.`);
 
 			const memberData = {
+				id: member.concat(`-${tx.nonce.toString()}`),
 				address: member,
+				addedBy: tx.id,
 				shared: subscriptionID,
 			};
 
@@ -99,15 +101,7 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 	subscriptionNFT.creatorAddress = DEV_ADDRESS;
 	await subscriptionsTable.upsert(subscriptionNFT, dbTrx);
 
-	await BluebirdPromise.map(
-		tx.params.member,
-		async member => {
-			logger.trace(`Remove member index for the members with address ${member}.`);
-			await membersTable.deleteByPrimaryKey(member, dbTrx);
-			logger.debug(`Updated member index for the members with address ${member}.`);
-		},
-		{ concurrency: tx.params.member.length },
-	);
+	await membersTable.delete({ shared: subscriptionID }, dbTrx);
 };
 
 module.exports = {

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/subscription/updateMembers.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/subscription/updateMembers.js
@@ -1,0 +1,105 @@
+const {
+	Logger,
+	MySQL: { getTableInstance },
+} = require('lisk-service-framework');
+const BluebirdPromise = require('bluebird');
+
+const config = require('../../../../config');
+
+const logger = Logger();
+
+const MYSQL_ENDPOINT = config.endpoints.mysql;
+const membersTableSchema = require('../../../database/schema/members');
+
+const getMembersTable = () => getTableInstance(
+	membersTableSchema.tableName,
+	membersTableSchema,
+	MYSQL_ENDPOINT,
+);
+
+// Command specific constants
+const COMMAND_NAME = 'updateMembers';
+
+// eslint-disable-next-line no-unused-vars
+const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
+	const membersTable = await getMembersTable();
+
+	const { subscriptionID } = tx.params;
+
+	logger.trace(`Removing existing members with subscription ID ${subscriptionID}.`);
+	const currentMembers = await membersTable.find(
+		{ shared: subscriptionID, removedBy: null },
+		['id', 'address', 'shared'],
+		dbTrx,
+	);
+
+	const currentAddresses = currentMembers.map(({ address }) => address);
+	const removed = currentMembers.filter(({ address }) => !tx.params.members.includes(address));
+	const added = tx.params.members.filter(member => !currentAddresses.includes(member));
+
+	await BluebirdPromise.map(
+		removed,
+		async member => {
+			const memberData = {
+				...member,
+				removedBy: tx.id,
+			};
+			logger.trace(`Updating account index for the account with address ${member}.`);
+			await membersTable.upsert(memberData, dbTrx);
+			logger.debug(`Updated account index for the account with address ${member}.`);
+		},
+		{ concurrency: removed.length },
+	);
+	logger.trace(`Removed existing members with subscription ID ${subscriptionID}.`);
+
+	logger.trace(`Adding new members with subscription ID ${subscriptionID}.`);
+	await BluebirdPromise.map(
+		added,
+		async member => {
+			const memberData = {
+				id: member.concat(`-${tx.nonce.toString()}`),
+				address: member,
+				addedBy: tx.id,
+				shared: subscriptionID,
+			};
+			logger.trace(`Updating account index for the account with address ${member}.`);
+			await membersTable.upsert(memberData, dbTrx);
+			logger.debug(`Updated account index for the account with address ${member}.`);
+		},
+		{ concurrency: added.length },
+	);
+	logger.trace(`Added new members with subscription ID ${subscriptionID}.`);
+};
+
+// eslint-disable-next-line no-unused-vars
+const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
+	const membersTable = await getMembersTable();
+
+	const removed = await membersTable.find(
+		{ removedBy: tx.id },
+		['id', 'address', 'shared'],
+		dbTrx,
+	);
+
+	await membersTable.delete({ addedBy: tx.id }, dbTrx);
+
+	await BluebirdPromise.map(
+		removed,
+		async member => {
+			const memberData = {
+				...member,
+				removedBy: null,
+			};
+			logger.trace(`Updating account index for the account with address ${member}.`);
+			await membersTable.upsert(memberData, dbTrx);
+			logger.debug(`Updated account index for the account with address ${member}.`);
+		},
+		{ concurrency: removed.length },
+	);
+};
+
+module.exports = {
+	COMMAND_NAME,
+	applyTransaction,
+	revertTransaction,
+};


### PR DESCRIPTION
### What was the problem?
This PR resolves #9

### How was it solved?
Updated members list to include `addedBy` and `removedBy`.  This enables me to distinguish the members that are added by certain transaction and revert the transaction if necessary.

I've updated the getSubscription business logic to only return members that are not removed (`removedBy: null`). This will ensure we'll return members according to the latest update.

### How was it tested?
- Updated unit tests
- Manually testsed
