### PR TITLE
Return audios by collectionID and ownerAddress

### DIFF
--- a/services/blockchain-indexer/shared/dataService/business/audios.js
+++ b/services/blockchain-indexer/shared/dataService/business/audios.js
@@ -47,10 +47,13 @@ const getAudios = async (params = {}) => {
 		// audiosID
 		const audioIDs = await ownersTable.find(
 			{ address: params.ownerAddress },
-			['audioID'],
+			['audioID', 'shares'],
 		);
+
+		const filteredAudioIDs = audioIDs.filter(audio => audio.shares > 0);
+
 		audioData = await BluebirdPromise.map(
-			audioIDs,
+			filteredAudioIDs,
 			async (audioID) => {
 				const audio = await audiosTable.find(
 					{ audioID: audioID.audioID },

--- a/services/blockchain-indexer/shared/dataService/business/audios.js
+++ b/services/blockchain-indexer/shared/dataService/business/audios.js
@@ -41,11 +41,34 @@ const getAudios = async (params = {}) => {
 	const ownersTable = await getOwnersIndex();
 	const featsTable = await getFeatsIndex();
 
-	const total = await audiosTable.count(params);
-	const audioData = await audiosTable.find(
-		{ ...params, limit: params.limit || total },
-		['audioID', 'creatorAddress', 'name', 'releaseYear', 'collectionID'],
-	);
+	let audioData = [];
+
+	if (params.ownerAddress) {
+		// audiosID
+		const audioIDs = await ownersTable.find(
+			{ address: params.ownerAddress },
+			['audioID'],
+		);
+		audioData = await BluebirdPromise.map(
+			audioIDs,
+			async (audioID) => {
+				const audio = await audiosTable.find(
+					{ audioID: audioID.audioID },
+					['audioID', 'creatorAddress', 'name', 'releaseYear', 'collectionID'],
+				);
+
+				return audio[0];
+			},
+			{ concurrency: audioIDs.length },
+		);
+	} else {
+		audioData = await audiosTable.find(
+			{ ...params, limit: params.limit },
+			['audioID', 'creatorAddress', 'name', 'releaseYear', 'collectionID'],
+		);
+	}
+
+	const total = audioData.length;
 
 	const data = await BluebirdPromise.map(
 		audioData,

--- a/services/blockchain-indexer/shared/dataService/business/audios.js
+++ b/services/blockchain-indexer/shared/dataService/business/audios.js
@@ -62,7 +62,7 @@ const getAudios = async (params = {}) => {
 
 				return audio[0];
 			},
-			{ concurrency: audioIDs.length },
+			{ concurrency: filteredAudioIDs.length },
 		);
 	} else {
 		audioData = await audiosTable.find(

--- a/services/gateway/apis/http-version3/methods/audios.js
+++ b/services/gateway/apis/http-version3/methods/audios.js
@@ -12,6 +12,7 @@ module.exports = {
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		audioID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
+		ownerAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 	},
 	get schema() {
 		const audioSchema = {};

--- a/services/gateway/apis/http-version3/methods/audios.js
+++ b/services/gateway/apis/http-version3/methods/audios.js
@@ -11,6 +11,7 @@ module.exports = {
 	params: {
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		audioID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
+		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 	},
 	get schema() {
 		const audioSchema = {};

--- a/services/gateway/tests/constants/generateDocs.js
+++ b/services/gateway/tests/constants/generateDocs.js
@@ -24,6 +24,12 @@ const createApiDocsExpectedResponse = {
 				{
 					$ref: '#/parameters/audioID',
 				},
+				{
+					$ref: '#/parameters/collectionID',
+				},
+				{
+					$ref: '#/parameters/ownerAddress',
+				},
 			],
 			responses: {
 				200: {


### PR DESCRIPTION
### What was the problem?
Closes #47 

We need to return audios based on the following params:
 - collectionID 
    We need this to display audios of a given collection. For example, when you open the page to a music album.
 - ownerAddress 
    This is used for collecting the list of audios that a user owns shares of. We'll use this in the profile page, and also for 
    reclaiming the profit. keep in mind the reclaim transaction doesn't need this endpoint param, it performs the job
    internally. But we need to show the audio profits in a dedicated list to he artist.
    
### How was it solved?
- [x] Add collectionID and ownerAddress parameters to the gateway API for the audios
- [x] Get the list of Audios for addresse have share > 0  

### How was it tested?
It tested Manualy