### PR TITLE
Issue updating social media accounts

### DIFF
--- a/services/blockchain-indexer/shared/database/schema/socialAccounts.js
+++ b/services/blockchain-indexer/shared/database/schema/socialAccounts.js
@@ -1,10 +1,10 @@
 module.exports = {
 	tableName: 'socialAccounts',
-	primaryKey: 'profileID',
+	primaryKey: ['profileID', 'platform'],
 	schema: {
 		profileID: { type: 'string' },
 		username: { type: 'string', null: true, defaultValue: null },
-		platform: { type: 'string', null: true, defaultValue: null },
+		platform: { type: 'string' },
 	},
 	indexes: {
 		profileID: { type: 'string' },

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/profile/create.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/profile/create.js
@@ -73,12 +73,11 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 		async socialAccount => {
 			const socialInfo = {
 				profileID: eventData.profileID,
-				username: socialAccount.username,
-				platform: socialAccount.platform,
+				...socialAccount,
 			};
-			logger.trace(`Inserting social sccounts for the profile with ID ${eventData.profileID}.`);
+			logger.trace(`Inserting social accounts for the profile with ID ${eventData.profileID}.`);
 			await socialAccountsTable.upsert(socialInfo, dbTrx);
-			logger.debug(`Inserted social sccounts for the profile with ID ${eventData.profileID}.`);
+			logger.debug(`Inserted social accounts for the profile with ID ${eventData.profileID}.`);
 			return true;
 		},
 		{ concurrency: tx.params.socialAccounts.length },

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/profile/setAttribute.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/profile/setAttribute.js
@@ -61,8 +61,7 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 		async (socialAccount) => {
 			const socialInfo = {
 				profileID: existingProfile.profileID,
-				username: socialAccount.username,
-				platform: socialAccount.platform,
+				...socialAccount,
 			};
 			logger.trace(`Updating social accounts for the profile with ID ${existingProfile.profileID}.`);
 			await socialAccountsTable.upsert(socialInfo, dbTrx);


### PR DESCRIPTION
### What was the problem?
This PR resolves #56

### How was it solved?
- We had a single primary key, profile ID, which meant every time trying to insert a new entry, we'd overwrite the previous one. 
I added the platform ID as the second primary key, resolving said issue.


