### PR TITLE
Add 'name' Parameter to Streamer API for Search Functionality

### DIFF
--- a/services/blockchain-indexer/shared/dataService/business/audios.js
+++ b/services/blockchain-indexer/shared/dataService/business/audios.js
@@ -41,6 +41,16 @@ const getAudios = async (params = {}) => {
 	const ownersTable = await getOwnersIndex();
 	const featsTable = await getFeatsIndex();
 
+	if (params.search) {
+		const { search, ...remParams } = params;
+		params = remParams;
+
+		params.search = {
+			property: 'name',
+			pattern: search,
+		};
+	}
+
 	let audioData = [];
 
 	if (params.ownerAddress) {

--- a/services/blockchain-indexer/shared/dataService/business/collections.js
+++ b/services/blockchain-indexer/shared/dataService/business/collections.js
@@ -15,6 +15,16 @@ const getCollectionsIndex = () => getTableInstance(
 const getCollections = async (params = {}) => {
 	const collectionsTable = await getCollectionsIndex();
 
+	if (params.search) {
+		const { search, ...remParams } = params;
+		params = remParams;
+
+		params.search = {
+			property: 'name',
+			pattern: search,
+		};
+	}
+
 	const total = await collectionsTable.count(params);
 	const resultSet = await collectionsTable.find(
 		{ ...params, limit: params.limit || 10 },

--- a/services/blockchain-indexer/shared/dataService/business/profiles.js
+++ b/services/blockchain-indexer/shared/dataService/business/profiles.js
@@ -22,6 +22,17 @@ const getSocialAccountsIndex = () => getTableInstance(
 
 const getProfiles = async (params = {}) => {
 	const profilesTable = await getProfilesIndex();
+
+	if (params.search) {
+		const { search, ...remParams } = params;
+		params = remParams;
+
+		params.search = {
+			property: 'name',
+			pattern: search,
+		};
+	}
+
 	const total = await profilesTable.count(params);
 	const profilesData = await profilesTable.find(
 		{ ...params, limit: params.limit || 10 },

--- a/services/gateway/apis/http-version3/methods/audios.js
+++ b/services/gateway/apis/http-version3/methods/audios.js
@@ -14,6 +14,7 @@ module.exports = {
 		audioID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		ownerAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
+		search: { optional: true, type: 'string' },
 		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10 },
 		offset: { optional: true, type: 'number', min: 0, default: 0 },
 	},

--- a/services/gateway/apis/http-version3/methods/audios.js
+++ b/services/gateway/apis/http-version3/methods/audios.js
@@ -9,7 +9,6 @@ module.exports = {
 	rpcMethod: 'get.audios',
 	tags: ['Audios'],
 	params: {
-		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		audioID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },

--- a/services/gateway/apis/http-version3/methods/audios.js
+++ b/services/gateway/apis/http-version3/methods/audios.js
@@ -9,6 +9,7 @@ module.exports = {
 	rpcMethod: 'get.audios',
 	tags: ['Audios'],
 	params: {
+		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		audioID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },

--- a/services/gateway/apis/http-version3/methods/collections.js
+++ b/services/gateway/apis/http-version3/methods/collections.js
@@ -12,6 +12,7 @@ module.exports = {
 		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
+		search: { optional: true, type: 'string' },
 	},
 	get schema() {
 		const collectionSchema = {};

--- a/services/gateway/apis/http-version3/methods/collections.js
+++ b/services/gateway/apis/http-version3/methods/collections.js
@@ -9,7 +9,6 @@ module.exports = {
 	rpcMethod: 'get.collections',
 	tags: ['Collections'],
 	params: {
-		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		search: { optional: true, type: 'string' },

--- a/services/gateway/apis/http-version3/methods/collections.js
+++ b/services/gateway/apis/http-version3/methods/collections.js
@@ -9,6 +9,7 @@ module.exports = {
 	rpcMethod: 'get.collections',
 	tags: ['Collections'],
 	params: {
+		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		collectionID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 	},

--- a/services/gateway/apis/http-version3/methods/profiles.js
+++ b/services/gateway/apis/http-version3/methods/profiles.js
@@ -13,6 +13,7 @@ module.exports = {
 		profileID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
 		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
 		nickName: { optional: true, type: 'string', pattern: /^[\w\s!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]{3,20}$/ },
+		search: { optional: true, type: 'string' },
 	},
 	get schema() {
 		const profileSchema = {};

--- a/services/gateway/apis/http-version3/methods/profiles.js
+++ b/services/gateway/apis/http-version3/methods/profiles.js
@@ -11,8 +11,6 @@ module.exports = {
 	params: {
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		profileID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
-		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
-		nickName: { optional: true, type: 'string', pattern: /^[\w\s!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]{3,20}$/ },
 		search: { optional: true, type: 'string' },
 	},
 	get schema() {

--- a/services/gateway/apis/http-version3/methods/profiles.js
+++ b/services/gateway/apis/http-version3/methods/profiles.js
@@ -11,6 +11,8 @@ module.exports = {
 	params: {
 		creatorAddress: { optional: true, type: 'string', min: 3, max: 41, pattern: regex.ADDRESS_LISK32 },
 		profileID: { optional: true, type: 'string', min: 1, max: 64, pattern: regex.HASH_SHA256 },
+		name: { optional: true, type: 'string', min: 3, max: 50, pattern: /^[A-Za-z0-9\s]{3,50}$/ },
+		nickName: { optional: true, type: 'string', pattern: /^[\w\s!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]{3,20}$/ },
 	},
 	get schema() {
 		const profileSchema = {};

--- a/services/gateway/sources/version3/audios.js
+++ b/services/gateway/sources/version3/audios.js
@@ -24,6 +24,7 @@ module.exports = {
 			name: '=,string',
 			role: '=,string',
 		}],
+		search: '=,string',
 		limit: '=,number',
 		offset: '=,number',
 		sort: '=,string',

--- a/services/gateway/sources/version3/collections.js
+++ b/services/gateway/sources/version3/collections.js
@@ -13,6 +13,7 @@ module.exports = {
 		// 	audioID: '=,string',
 		// 	name: '=,number',
 		// }],
+		search: '=,string',
 		limit: '=,number',
 		offset: '=,number',
 		sort: '=,string',

--- a/services/gateway/sources/version3/profiles.js
+++ b/services/gateway/sources/version3/profiles.js
@@ -17,6 +17,7 @@ module.exports = {
 		bannerHash: '=,string',
 		bannerSignature: '=,string',
 		creatorAddress: '=,string',
+		search: '=,string',
 	},
 	definition: {
 		data: ['data', profile],

--- a/services/gateway/tests/constants/generateDocs.js
+++ b/services/gateway/tests/constants/generateDocs.js
@@ -19,9 +19,6 @@ const createApiDocsExpectedResponse = {
 			description: 'Returns audios data\n RPC => get.audios',
 			parameters: [
 				{
-					$ref: '#/parameters/name',
-				},
-				{
 					$ref: '#/parameters/creatorAddress',
 				},
 				{
@@ -32,6 +29,9 @@ const createApiDocsExpectedResponse = {
 				},
 				{
 					$ref: '#/parameters/ownerAddress',
+				},
+				{
+					$ref: '#/parameters/search',
 				},
 				{
 					$ref: '#/parameters/limit',
@@ -458,13 +458,13 @@ const createApiDocsExpectedResponse = {
 			description: 'Returns collections data\n RPC => get.collections',
 			parameters: [
 				{
-					$ref: '#/parameters/name',
-				},
-				{
 					$ref: '#/parameters/creatorAddress',
 				},
 				{
 					$ref: '#/parameters/collectionID',
+				},
+				{
+					$ref: '#/parameters/search',
 				},
 			],
 			responses: {
@@ -936,10 +936,7 @@ const createApiDocsExpectedResponse = {
 					$ref: '#/parameters/profileID',
 				},
 				{
-					$ref: '#/parameters/name',
-				},
-				{
-					$ref: '#/parameters/nickName',
+					$ref: '#/parameters/search',
 				},
 			],
 			responses: {

--- a/services/gateway/tests/constants/generateDocs.js
+++ b/services/gateway/tests/constants/generateDocs.js
@@ -19,6 +19,9 @@ const createApiDocsExpectedResponse = {
 			description: 'Returns audios data\n RPC => get.audios',
 			parameters: [
 				{
+					$ref: '#/parameters/name',
+				},
+				{
 					$ref: '#/parameters/creatorAddress',
 				},
 				{
@@ -454,6 +457,9 @@ const createApiDocsExpectedResponse = {
 		get: {
 			description: 'Returns collections data\n RPC => get.collections',
 			parameters: [
+				{
+					$ref: '#/parameters/name',
+				},
 				{
 					$ref: '#/parameters/creatorAddress',
 				},
@@ -928,6 +934,12 @@ const createApiDocsExpectedResponse = {
 				},
 				{
 					$ref: '#/parameters/profileID',
+				},
+				{
+					$ref: '#/parameters/name',
+				},
+				{
+					$ref: '#/parameters/nickName',
 				},
 			],
 			responses: {


### PR DESCRIPTION
### What was the problem?
When using the player's search bar to search for the name of a profile, collection, or audio, an error message is returned from
the Streamer API's gateway. The error message states: "Unknown input parameter(s): name". To improve user experience
and enable more effective searches, we need to add four new search parameters to the Streamer API's gateway.

### How was it solved?
Add name and its schema-based type as parameters to the gateway/apis/http-v3/profiles, collections, and audios.